### PR TITLE
Including adaptive resampling

### DIFF
--- a/neural_mfg.py
+++ b/neural_mfg.py
@@ -183,7 +183,7 @@ class dgm_net:
         res_HJB, res_KFP, _, _, _, _ = self.get_loss_terms(0,X_out,X_in,X_b)
         
         PDEs_residual = pd.DataFrame(res_HJB.numpy() + res_KFP.numpy())
-        PDEs_residual.sort_values(by=PDEs_residual.columns[1])
+        PDEs_residual.sort_values(by=PDEs_residual.columns[1], ascending=False)
         
         X_b_new     = [] 
         X_in_new    = []


### PR DESCRIPTION
The training phase has been updated as follows:
- the get_loss() method has been split in two (one for computing the residuals, one for computing the l2 norm and adding all up);
- an additional method  resample() has been added
- in the method train(), after few iteration, the resampling is performed The resampling adds M points after each sampling_step iterations following the method RAR-G (see https://arxiv.org/pdf/2207.10289.pdf)

A change is needed in config.json, as two additional attributes 'M' and 'resampling_step' have been added to "dgm_params". We need to find an appropriate value for both the attributes. Following what has been done in the paper, at the moment there's a "standard" training without resampling lasting for training_steps steps, followed by another training with resampling, also training_steps steps long. By default, we can consider M=100 and resampling_step=100.